### PR TITLE
added fix to correctly escape upid in task log which contains backslashes

### DIFF
--- a/agents/plugins/proxmox_bs
+++ b/agents/plugins/proxmox_bs
@@ -94,7 +94,7 @@ done
 # shellcheck disable=SC2086 disable=SC2002
 cat $TMP_UPIDS | while read -r upid; do
   command_section -P "sed '/^Removed /,\$!d'" -p "$upid" \
-    "proxmox-backup-manager task log" "$upid" '2>&1'
+    "proxmox-backup-manager task log" "${upid//\\/\\\\}" '2>&1'
 done
 
 export PBS_PASSWORD=


### PR DESCRIPTION
This PR fixes an issue with ChecMK always showing `GC Task failed` if a data store in PBS contains some special characters like `-`. This results in the UPID in the `garbage-collection status` step to return something like:

```
UPID:hostname:0000029A:000001C1:00000013:6417CC30:garbage_collection:test\x2dstore:root@pam:
```

for a data store called `test-store`

This is a result of the `jq -r '.upid'` call in the `garbage-collection status` step where JQ not only removes the quotes, but also the double-backslashes. However, removing the `-r` option does not seem to be a valid alternative since this leaves the quotes and also does not make sure the normal `$upid` is used in line before this single-line change.

With this simple bash char replacement `task log` is used with the correct escaped string while the `command_section` call keeps up using the upid returned by `garbage-collection status`.